### PR TITLE
improvements to headroom calculation progress tracking

### DIFF
--- a/gridcapacity/capacity_analysis.py
+++ b/gridcapacity/capacity_analysis.py
@@ -19,7 +19,7 @@ import logging
 from collections import OrderedDict, defaultdict
 from collections.abc import Collection
 from dataclasses import dataclass
-from typing import Final, Generator, Iterator, List, Optional, Tuple
+from typing import Final, Generator, Iterator, Optional, Tuple
 
 from gridcapacity.backends.subsystems import (
     Bus,

--- a/gridcapacity/capacity_analysis.py
+++ b/gridcapacity/capacity_analysis.py
@@ -238,7 +238,7 @@ class CapacityAnalyser:
         PowerFlows.reset_count()
         ViolationsStats.reset()
 
-        def generate():
+        def generate() -> Generator[tuple[BusHeadroom, int]]:
             for bus in buses:
                 if (
                     self._selected_buses_ids is None

--- a/gridcapacity/capacity_analysis.py
+++ b/gridcapacity/capacity_analysis.py
@@ -64,7 +64,7 @@ class BusHeadroom:
     gen_lf: Optional[LimitingFactor]
 
 
-Headroom = tuple[BusHeadroom, ...]
+Headroom = List[BusHeadroom]
 
 
 @dataclass(frozen=True)
@@ -226,7 +226,7 @@ class CapacityAnalyser:
                 progress.update()
                 headroom.append(bus_headroom)
 
-        return tuple(headroom)
+        return headroom
 
     def create_buses_headroom_generator(self):
         buses: Buses = Buses()

--- a/gridcapacity/capacity_analysis.py
+++ b/gridcapacity/capacity_analysis.py
@@ -212,7 +212,7 @@ class CapacityAnalyser:
         console.print("Analysing headroom", style="blue")
 
         generate, total = self.create_buses_headroom_generator()
-        headroom: List[BusHeadroom] = []
+        headroom: list[BusHeadroom] = []
 
         with tqdm(
             total=total


### PR DESCRIPTION
This PR will allow tracking progress of headroom calculation programatically.
Here is usage example

```python
from gridcapacity.capacity_analysis import CapacityAnalyser
from gridcapacity.config import ConfigModel
from gridcapacity.output import json_dump_kwargs

capacity_analyser = CapacityAnalyser(**kw)  # kw provided outside example
headroom = []
generate, total = capacity_analyser.create_buses_headroom_generator()

for i, (bus_headroom, powerflow_count) in enumerate(generate()):
    print(
        f"progress={i}/{total}, powerflow_count={powerflow_count}"
    )
    headroom.append(bus_headroom)
```