### PR TITLE
Fix PandaPower string buses

### DIFF
--- a/gridcapacity/backends/subsystems/bus.py
+++ b/gridcapacity/backends/subsystems/bus.py
@@ -52,17 +52,23 @@ class BusBase:
         loads_available: bool = True
         try:
             load: Load = next(loads_iterator)
-        except StopIteration:
+        except (StopIteration, KeyError):
             loads_available = False
-        # Buses and loads are sorted by bus number [PSSE API.pdf].
-        # So loads are iterated until load bus number is lower or equal
-        # to the bus number.
-        while loads_available and load.number <= self.number:
+        while loads_available:
+            # Buses and loads are sorted by bus number [PSSE API.pdf].
+            # So PSSE loads are iterated until load bus number is lower or equal
+            # to the bus number.
+            if (
+                sys.platform == "win32"
+                and not envs.pandapower_backend
+                and load.number <= self.number
+            ):
+                break
             if load.number == self.number:
                 actual_load_mva += load.mva_act
             try:
                 load = next(loads_iterator)
-            except StopIteration:
+            except (StopIteration, KeyError):
                 loads_available = False
         return actual_load_mva
 
@@ -73,17 +79,23 @@ class BusBase:
         machines_available: bool = True
         try:
             machine: Machine = next(machines_iterator)
-        except StopIteration:
+        except (StopIteration, KeyError):
             machines_available = False
-        # Buses and machines are sorted by bus number [PSSE API.pdf].
-        # So machines are iterated until machine bus number is lower or equal
-        # to the bus number.
-        while machines_available and machine.number <= self.number:
+        while machines_available:
+            # Buses and machines are sorted by bus number [PSSE API.pdf].
+            # So PSSE machines are iterated until machine bus number is lower or equal
+            # to the bus number.
+            if (
+                sys.platform == "win32"
+                and not envs.pandapower_backend
+                and machine.number <= self.number
+            ):
+                break
             if machine.number == self.number:
                 actual_gen_mva += machine.pq_gen
             try:
                 machine = next(machines_iterator)
-            except StopIteration:
+            except (StopIteration, KeyError):
                 machines_available = False
         return actual_gen_mva
 

--- a/gridcapacity/capacity_analysis.py
+++ b/gridcapacity/capacity_analysis.py
@@ -172,12 +172,16 @@ class CapacityAnalyser:
             connections_available = False
         for bus in Buses():
             if connections_available and bus.number == bus_number:
-                if (load_connection := connection.load) is not None:
+                if (
+                    load_connection := connection.load
+                ) is not None and load_connection.p_mw:
                     bus.add_load(
                         p_to_mva(load_connection.p_mw, load_connection.pf),
                         "CR",
                     )
-                if (gen_connection := connection.gen) is not None:
+                if (
+                    gen_connection := connection.gen
+                ) is not None and gen_connection.p_mw:
                     bus.add_gen(
                         p_to_mva(gen_connection.p_mw, gen_connection.pf),
                         "CR",

--- a/gridcapacity/config.py
+++ b/gridcapacity/config.py
@@ -16,7 +16,7 @@ limitations under the License.
 import json
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Union
 
 from pydantic import BaseModel, NonNegativeFloat, NonNegativeInt, PositiveInt, confloat
 
@@ -45,7 +45,7 @@ class ConfigModel(BaseModel):
     upper_gen_limit_p_mw: NonNegativeFloat
     load_power_factor: Optional[NonNegativeFloat] = 0.9
     gen_power_factor: Optional[NonNegativeFloat] = 0.9
-    selected_buses_ids: Optional[list[NonNegativeInt]]
+    selected_buses_ids: Optional[list[Union[NonNegativeInt, str]]]
     headroom_tolerance_p_mw: Optional[NonNegativeFloat] = 5.0
     solver_opts: Optional[dict] = None
     max_iterations: Optional[PositiveInt] = 10


### PR DESCRIPTION
Fix PandaPower string buses

Could be testes with a following configuration file:
```json
{
    "case_name": "/app/cim_cgmes.json",
    "upper_load_limit_p_mw": 100.0,
    "upper_gen_limit_p_mw": 100.0,
    "load_power_factor": 0.9,
    "gen_power_factor": 0.9,
    "selected_buses_ids":  ["TannrsCk1", "Delaware"],
    "headroom_tolerance_p_mw": 5.0,
    "solver_opts": null,
    "max_iterations": 10,
    "normal_limits": null,
    "contingency_limits": null,
    "contingency_scenario": null,
    "use_full_newton_raphson": false,
    "connection_scenario": {
        "Delaware": {
            "load": [
                161.0
            ]
        }
    }
}
```